### PR TITLE
fix: AppData installation dir

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -17,7 +17,7 @@ appstream_file = i18n.merge_file(
        output: 'xyz.ketok.Speedtest.appdata.xml',
        po_dir: '../po',
       install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 appstream_util = find_program('appstream-util', required: false)


### PR DESCRIPTION
Trying to package your app for Fedora and got RPM linter error due old, deprecated AppData location.

>  The application-metainfo files override any values which are automatically fetched by the AppStream data generator. Applications can ship one or more files in /usr/share/**metainfo**/%{id}.metainfo.xml. 

https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#qsr-app-introduction

Thanks in advance!