### PR TITLE
fix: Add executable bit to speedtest

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -36,7 +36,7 @@ configure_file(
   configuration: conf,
   install: true,
   install_dir: get_option('bindir'),
-  install_mode: 'r-xr--r--'
+  install_mode: 'r-xr-xr-x'
 )
 
 speedtest_sources = [


### PR DESCRIPTION
This allow app to run as non-root user. In current state packaged RPM and app not launch at all and requires root privileges.