### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/xyz.ketok.Speedtest.metainfo.xml.in
+++ b/data/xyz.ketok.Speedtest.metainfo.xml.in
@@ -32,7 +32,7 @@
 
     <releases>
         <release version="1.3.0" date="2024-01-27">
-            <description translatable="no">
+            <description translate="no">
                 <ul>
                     <li>UI Redesign (with mobile device support!)</li>
                     <li>Update Italian translation</li>
@@ -41,7 +41,7 @@
         </release>
 
         <release version="1.2.1" date="2023-12-24">
-            <description translatable="no">
+            <description translate="no">
                 <ul>
                     <li>Occitan translation</li>
                     <li>Update French translation</li>
@@ -50,7 +50,7 @@
         </release>
 
         <release version="1.2.0" date="2023-11-07">
-            <description translatable="no">
+            <description translate="no">
                 <ul>
                     <li>Add preferences dialog</li>
                     <li>Italian translation</li>
@@ -59,7 +59,7 @@
         </release>
 
         <release version="1.1.2" date="2023-10-05">
-            <description translatable="no">
+            <description translate="no">
                 <ul>
                     <li>French translation</li>
                     <li>Russian translation</li>
@@ -68,7 +68,7 @@
         </release>
 
 		<release version="1.1.1" date="2023-10-01">
-            <description translatable="no">
+            <description translate="no">
 				<ul>
 					<li>Turkish translation</li>
 					<li>Fix the version displayed in the about window being outdated</li>
@@ -77,7 +77,7 @@
         </release>
 
 		<release version="1.1.0" date="2023-09-27">
-            <description translatable="no">
+            <description translate="no">
 				<ul>
 					<li>User interface changes</li>
 					<li>Improve the code for gathering the server list</li>
@@ -87,7 +87,7 @@
         </release>
 
 		<release version="1.0.1" date="2023-09-12">
-            <description translatable="no">
+            <description translate="no">
 				<ul>
 					<li>Improve the icon's contrast with the flathub website</li>
 					<li>Internal improvements</li>
@@ -96,7 +96,7 @@
         </release>
 
 		<release version="1.0.0" date="2023-09-09">
-            <description translatable="no">
+            <description translate="no">
                 <p>Initial release</p>
             </description>
         </release>

--- a/data/xyz.ketok.Speedtest.metainfo.xml.in
+++ b/data/xyz.ketok.Speedtest.metainfo.xml.in
@@ -7,6 +7,8 @@
 
     <url type="homepage">https://github.com/Ketok4321/speedtest</url>
     <url type="bugtracker">https://github.com/Ketok4321/speedtest/issues</url>
+    <url type="vcs-browser">https://github.com/Ketok4321/speedtest</url>
+    <url type="translate">https://github.com/Ketok4321/speedtest/tree/main/po</url>
 
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

Also correct translatable usage.

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html