### PR TITLE
Add 10 Gbps gauge scale

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -38,7 +38,7 @@ class SpeedtestPreferencesWindow(Adw.PreferencesWindow):
     theme = Gtk.Template.Child()
     gauge_scale = Gtk.Template.Child()
 
-    SCALES = [100, 250, 500, 1000]
+    SCALES = [100, 250, 500, 1000, 10000]
 
     def __init__(self, app, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Internet connections over 1 Gbps are getting more and more common. That's why this PR adds a 10 Gbps gauge scale.