### PR TITLE
add "Network" to categories in desktop file

### DIFF
--- a/data/xyz.ketok.Speedtest.desktop.in
+++ b/data/xyz.ketok.Speedtest.desktop.in
@@ -4,5 +4,5 @@ Exec=speedtest
 Icon=@APP_ID@
 Terminal=false
 Type=Application
-Categories=GTK;
+Categories=GTK;Network;
 StartupNotify=true


### PR DESCRIPTION
The category "Network" should be added to the categories in the desktop file so that this application nicely integrates into the start menu and app folders of current Linux desktop environments.